### PR TITLE
[FIX] use of MaintenanceTask::schedule instead of "reschedule" + too …

### DIFF
--- a/MMOCoreORB/src/server/zone/objects/structure/events/StructureMaintenanceTask.cpp
+++ b/MMOCoreORB/src/server/zone/objects/structure/events/StructureMaintenanceTask.cpp
@@ -30,8 +30,7 @@ void StructureMaintenanceTask::run() {
 		return;
 
 	if (zoneServer->isServerLoading()) {
-		schedule(1000);
-
+		reschedule(20 * 1000);
 		return;
 	}
 


### PR DESCRIPTION
on busy server at start time, you're getting bunches of :

`(149 s) [Console] ERROR - exception caught while running a task                                                 
IllegalArgumentException - task is already scheduled          
(149 s) [StackTrace] WARNING - /home/swgemu/MMOCoreORB/bin/core3(_ZN3sys4lang10StackTraceC1Ev+0x1d) [0x5555571ee
7cf]
/home/swgemu/MMOCoreORB/bin/core3(_ZN3sys4lang9ExceptionC1ERKNS0_6StringE+0x43) [0x5555571ec5fd]                
/home/swgemu/MMOCoreORB/bin/core3(_ZN3sys4lang24IllegalArgumentExceptionC2ENS0_6StringE+0x46) [0x55555729b990]  
/home/swgemu/MMOCoreORB/bin/core3(_ZN6engine4core15TaskManagerImpl12scheduleTaskEPNS0_4TaskEy+0x96) [0x55555729a
56e]
/home/swgemu/MMOCoreORB/bin/core3(_ZN6engine4core4Task8scheduleEy+0x37) [0x55555728525d]                        
/home/swgemu/MMOCoreORB/bin/core3(_ZN6server4zone7objects9structure6events24StructureMaintenanceTask3runEv+0x225
) [0x555556a1c2dd]
/home/swgemu/MMOCoreORB/bin/core3(_ZN6engine4core4Task9doExecuteEv+0x62) [0x5555572850c8]                       
/home/swgemu/MMOCoreORB/bin/core3(_ZN6engine4core16TaskWorkerThread3runEv+0x1aa) [0x55555727c0e4]`


on top of that the timer of 1 second (1000 millisecond) is too short as i saw same structure report the issue several times, I made it 20 seconds (make your own numbers!).