### PR TITLE
[fixed] missing jdk package in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,7 @@ RUN set -xe; \
         cppcheck \
         curl \
         db5.3-util \
+        default-jdk \
         dnsutils \
         doxygen \
         figlet \


### PR DESCRIPTION
#14 closed when I force pushed my commit tree back to the right spot. This PR should be just the one commit to fix the dockerfile.