### PR TITLE
Fix tutorial: roonName typo made isInRoom always return false (tutorial cannot be completed)

### DIFF
--- a/MMOCoreORB/bin/scripts/screenplays/tutorial/tutorial.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/tutorial/tutorial.lua
@@ -2033,7 +2033,7 @@ end
 
 -- Checks if room is complete
 function TutorialScreenPlay:isRoomComplete(pPlayer, roomName)
-	if (pPlayer == nil or roonName == nil or roomName == "") then
+	if (pPlayer == nil or roomName == nil or roomName == "") then
 		return false
 	end
 
@@ -2042,7 +2042,7 @@ end
 
 -- Checks if player is in a room
 function TutorialScreenPlay:isInRoom(pPlayer, roomName)
-	if (pPlayer == nil or roonName == nil or roomName == "") then
+	if (pPlayer == nil or roomName == nil or roomName == "") then
 		return false
 	end
 


### PR DESCRIPTION
## Summary

`TutorialScreenPlay:isInRoom` and `isRoomComplete` (tutorial.lua ~2036/2045) have nil-guards that read an undefined variable `roonName` instead of the `roomName` parameter. `roonName == nil` is always true, so **`isInRoom` returns false on every call**.

Every tutorial room handler guards on `isInRoom` and silently returns:

- no room 1 steps fire (welcome, movement, chat lesson, holocron)
- the room 2 supply drum permission (`RoomTwoItemDrum`) is never granted — players cannot open the drum and cannot meaningfully progress
- no HUD elements are taught

Spawns and conversation handlers work normally (they don't consult `isInRoom`), which disguises the failure as a step-machine bug. The machine simply cannot see which room the player is in.

## Diagnosis evidence

On a live server with a fresh character that had completed the room-2 greeter conversation, shared-memory state read:

```
r1step=0 r2step=0 doneConvo=1 drumFound=true hasPerm=false
```

i.e. the conversation handler fired and scheduled `handleRoomTwo`, but no room handler had ever executed a step — all exited at the `isInRoom` guard.

## Fix

`roonName` → `roomName` (2 characters, 2 lines).

## Verification

After this change (hot-reloaded via `reloadscreenplays`), a brand-new character completed the **entire tutorial end-to-end** — all rooms, drum, bank/bazaar explanations, cloning, combat room, medic trainer, quartermaster, and clean exit to the galaxy. Before the change, a fresh character could not get past the room-2 drum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QY5yS6zpnPRipkskrmF8aG